### PR TITLE
feat: add multi-threaded MuJoCo WASM support

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,7 @@ jobs:
       uses: actions/checkout@v5
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v7
       with:
         python-version: '3.12'
 

--- a/examples/demo/simple.py
+++ b/examples/demo/simple.py
@@ -140,9 +140,9 @@ def setup_builder() -> mjswan.Builder:
         name="G1",
     ).set_viewer_config(
         mjswan.ViewerConfig(
-            lookat=(0.0, 0.0, 0.7),
-            distance=3.7,
-            elevation=-13.0,
+            lookat=(0.0, 0.0, 0.0),
+            distance=2.5,
+            elevation=-10.0,
             azimuth=-34.0,
             origin_type=mjswan.ViewerConfig.OriginType.ASSET_BODY,
             body_name="torso_link",

--- a/examples/mjlab/commands/LiftingCommand.ts
+++ b/examples/mjlab/commands/LiftingCommand.ts
@@ -1,5 +1,5 @@
 import * as THREE from 'three';
-import type { MjModel } from '@mujoco/mujoco';
+import type { MjModel } from 'mujoco';
 import type { CommandConfigEntry, CommandTerm, CommandTermContext } from './types';
 import { mjcToThreeCoordinate } from '../scene/coordinate';
 

--- a/examples/mjlab/defaults.py
+++ b/examples/mjlab/defaults.py
@@ -40,7 +40,7 @@ TASK_RUN_ID_MAP: dict[str, str | list[str]] = {
 
 
 def main():
-    builder = mjswan.Builder()
+    builder = mjswan.Builder(mt=True)
     project = builder.add_project(name="mjlab Tasks")
     export_contexts = []
 

--- a/examples/mjlab/events/ResetJointsByOffset.ts
+++ b/examples/mjlab/events/ResetJointsByOffset.ts
@@ -64,7 +64,7 @@ export class ResetJointsByOffset extends EventBase {
     return min + Math.random() * (max - min);
   }
 
-  private resolveJointIndices(mjModel: import('@mujoco/mujoco').MjModel): number[] {
+  private resolveJointIndices(mjModel: import('mujoco').MjModel): number[] {
     if (this.jointIds && this.jointIds.length > 0) {
       return this.jointIds.filter((idx) => idx >= 0 && idx < mjModel.njnt);
     }
@@ -121,7 +121,7 @@ export class ResetJointsByOffset extends EventBase {
     return null;
   }
 
-  private getModelJointNames(mjModel: import('@mujoco/mujoco').MjModel): string[] {
+  private getModelJointNames(mjModel: import('mujoco').MjModel): string[] {
     const namesArray = new Uint8Array(mjModel.names);
     const decoder = new TextDecoder();
     const names: string[] = [];

--- a/examples/mjlab/observations/EeToObjectDistance.ts
+++ b/examples/mjlab/observations/EeToObjectDistance.ts
@@ -1,5 +1,5 @@
 import * as THREE from 'three';
-import type { MjModel } from '@mujoco/mujoco';
+import type { MjModel } from 'mujoco';
 import { ObservationBase } from './ObservationBase';
 import type { ObservationConfig } from './ObservationBase';
 import type { PolicyRunner } from '../policy/PolicyRunner';

--- a/examples/mjlab/observations/HeightScan.ts
+++ b/examples/mjlab/observations/HeightScan.ts
@@ -1,5 +1,5 @@
 import * as THREE from 'three';
-import type { MjData } from '@mujoco/mujoco';
+import type { MjData } from 'mujoco';
 import { ObservationBase } from './ObservationBase';
 import type { ObservationConfig } from './ObservationBase';
 import type { PolicyRunner } from '../policy/PolicyRunner';
@@ -381,7 +381,7 @@ export class HeightScan extends ObservationBase {
     return typeof value === 'number' && Number.isFinite(value) ? value : fallback;
   }
 
-  private getModelBodyNames(mjModel: import('@mujoco/mujoco').MjModel): string[] {
+  private getModelBodyNames(mjModel: import('mujoco').MjModel): string[] {
     const namesArray = new Uint8Array(mjModel.names);
     const decoder = new TextDecoder();
     const names: string[] = [];
@@ -456,7 +456,7 @@ export class HeightScan extends ObservationBase {
   }
 
   private resolveFrameIndex(
-    mjModel: import('@mujoco/mujoco').MjModel,
+    mjModel: import('mujoco').MjModel,
     frameType: FrameType,
     frameRefNameValue: unknown
   ): number {

--- a/examples/mjlab/observations/ObjectToGoalDistance.ts
+++ b/examples/mjlab/observations/ObjectToGoalDistance.ts
@@ -1,5 +1,5 @@
 import * as THREE from 'three';
-import type { MjModel } from '@mujoco/mujoco';
+import type { MjModel } from 'mujoco';
 import { ObservationBase } from './ObservationBase';
 import type { ObservationConfig } from './ObservationBase';
 import type { PolicyRunner } from '../policy/PolicyRunner';

--- a/src/mjswan/_build_client.py
+++ b/src/mjswan/_build_client.py
@@ -465,7 +465,11 @@ class ClientBuilder:
         output_path.write_text("\n".join(lines))
 
     def build(
-        self, clean: bool = False, base_path: str = "/", gtm_id: str | None = None
+        self,
+        clean: bool = False,
+        base_path: str = "/",
+        gtm_id: str | None = None,
+        mt: bool = False,
     ) -> None:
         try:
             self.create_env(clean=clean)
@@ -479,6 +483,8 @@ class ClientBuilder:
             env: dict[str, str] = {"MJSWAN_BASE_PATH": base_path}
             if gtm_id:
                 env["MJSWAN_GTM_ID"] = gtm_id
+            if mt:
+                env["MJSWAN_MT"] = "1"
             self.run_build_script("build", env=env)
             print("✓ Build completed successfully")
         except subprocess.CalledProcessError as e:
@@ -501,7 +507,11 @@ def ensure_node_env(
 
 
 def build_client(
-    project_dir: Path, clean: bool = False, script: str = "build", base_path: str = "/"
+    project_dir: Path,
+    clean: bool = False,
+    script: str = "build",
+    base_path: str = "/",
+    mt: bool = False,
 ) -> None:
     builder = ClientBuilder(project_dir)
-    builder.build(clean=clean, base_path=base_path)
+    builder.build(clean=clean, base_path=base_path, mt=mt)

--- a/src/mjswan/builder.py
+++ b/src/mjswan/builder.py
@@ -39,16 +39,25 @@ class Builder:
     interactive MuJoCo simulations with ONNX policies. It handles projects, scenes, and policies hierarchically.
     """
 
-    def __init__(self, base_path: str = "/", gtm_id: str | None = None) -> None:
+    def __init__(
+        self,
+        base_path: str = "/",
+        gtm_id: str | None = None,
+        mt: bool = False,
+    ) -> None:
         """Initialize a new Builder instance.
 
         Args:
             base_path: Base path for subdirectory deployment (e.g., '/mjswan/').
             gtm_id: Google Tag Manager ID (e.g., 'GTM-XXXXXXX'). Injects GTM snippet if set.
+            mt: Enable multi-threaded MuJoCo WASM. Requires COOP/COEP headers — these are
+                written as a ``_headers`` file (Netlify/Cloudflare Pages/Vercel) and a
+                service worker (required for GitHub Pages hosting). Defaults to False.
         """
         self._projects: list[ProjectConfig] = []
         self._base_path = base_path
         self._gtm_id = gtm_id
+        self._mt = mt
 
     @classmethod
     def from_mjlab(
@@ -59,6 +68,7 @@ class Builder:
         play: bool = False,
         base_path: str = "/",
         gtm_id: str | None = None,
+        mt: bool = False,
     ) -> Builder:
         """Create a Builder pre-configured with a single mjlab task.
 
@@ -89,7 +99,7 @@ class Builder:
             app = builder.build()
             ```
         """
-        builder = cls(base_path=base_path, gtm_id=gtm_id)
+        builder = cls(base_path=base_path, gtm_id=gtm_id, mt=mt)
         project = builder.add_project(name=project_name)
         project.add_mjlab_scene(task_id, play=play)
         return builder
@@ -251,6 +261,22 @@ class Builder:
         with open(root_config_file, "w") as f:
             json.dump(root_config, f, indent=2)
 
+    def _save_mt_headers(self, output_path: Path) -> None:
+        """Write COOP/COEP response headers needed by multi-threaded MuJoCo.
+
+        Two mechanisms are written so the output works on any static host:
+        - ``_headers``: honored by Netlify, Cloudflare Pages, and Vercel.
+        - ``coi-serviceworker.js`` (emitted by the Vite build only when mt=True): used by the
+          injected inline script for GitHub Pages, which cannot set response headers.
+        """
+        headers_content = (
+            "/*\n"
+            "  Cross-Origin-Opener-Policy: same-origin\n"
+            "  Cross-Origin-Embedder-Policy: require-corp\n"
+            "\n"
+        )
+        (output_path / "_headers").write_text(headers_content)
+
     def _build_splat_config_dict(self, scene: SceneConfig, splat: SplatConfig) -> dict:
         """Build the splat dict for config.json.
 
@@ -308,7 +334,11 @@ class Builder:
             if package_json.exists():
                 print("Building the mjswan application...")
                 builder = ClientBuilder(template_dir)
-                builder.build(base_path=self._base_path, gtm_id=self._gtm_id)
+                builder.build(
+                    base_path=self._base_path,
+                    gtm_id=self._gtm_id,
+                    mt=self._mt,
+                )
 
             # Copy all files from template to output_path
             shutil.copytree(
@@ -373,6 +403,10 @@ class Builder:
 
         # Save root configuration (project metadata and structure)
         self._save_config_json(output_path)
+
+        # Write COOP/COEP headers for multi-threaded MuJoCo (SharedArrayBuffer)
+        if self._mt:
+            self._save_mt_headers(output_path)
 
         # Save MuJoCo models and ONNX policies per project
         max_name_len = max(len(p.name) for p in self._projects)

--- a/src/mjswan/template/_mt/coi-serviceworker.js
+++ b/src/mjswan/template/_mt/coi-serviceworker.js
@@ -1,0 +1,51 @@
+/* coi-serviceworker — vendored from https://github.com/gzuidhof/coi-serviceworker (MIT)
+ *
+ * Only required for GitHub Pages hosting, which cannot set custom response headers.
+ * On Netlify / Cloudflare Pages / Vercel the _headers file is sufficient instead.
+ * On local `app.launch()` the Python server already sends COOP/COEP — no SW needed.
+ */
+
+self.addEventListener("install", () => self.skipWaiting());
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    self.clients.claim().then(() =>
+      self.clients.matchAll().then((clients) =>
+        clients.forEach((client) => client.postMessage({ type: "activated" }))
+      )
+    )
+  );
+});
+
+self.addEventListener("fetch", (event) => {
+  // Chrome extensions and non-http(s) requests — skip
+  if (!event.request.url.startsWith("http")) return;
+
+  // Avoid a failed fetch for opaque same-origin requests
+  if (
+    event.request.cache === "only-if-cached" &&
+    event.request.mode !== "same-origin"
+  ) {
+    return;
+  }
+
+  event.respondWith(
+    fetch(event.request)
+      .then((response) => {
+        // Opaque responses (cross-origin, no-cors) — pass through unchanged
+        if (response.status === 0) return response;
+
+        const headers = new Headers(response.headers);
+        headers.set("Cross-Origin-Opener-Policy", "same-origin");
+        headers.set("Cross-Origin-Embedder-Policy", "require-corp");
+        headers.set("Cross-Origin-Resource-Policy", "cross-origin");
+
+        return new Response(response.body, {
+          status: response.status,
+          statusText: response.statusText,
+          headers,
+        });
+      })
+      .catch(() => fetch(event.request))
+  );
+});

--- a/src/mjswan/template/src/components/MjswanViewer.tsx
+++ b/src/mjswan/template/src/components/MjswanViewer.tsx
@@ -54,7 +54,9 @@ const MjswanViewer = ({
     const init = async () => {
       notify('Loading MuJoCo...');
       if (!mujocoRef.current) {
-        const mujocoModule = await import('mujoco');
+        const mujocoModule = __MUJOCO_MT__
+          ? await import('mujoco/mt')
+          : await import('mujoco');
         mujocoRef.current = await mujocoModule.default();
       }
       if (cancelled) {

--- a/src/mjswan/template/src/vite-env.d.ts
+++ b/src/mjswan/template/src/vite-env.d.ts
@@ -1,1 +1,4 @@
 /// <reference types="vite/client" />
+
+/** Injected by Vite at build time. True when building the multi-threaded MuJoCo variant. */
+declare const __MUJOCO_MT__: boolean;

--- a/src/mjswan/template/vite.config.ts
+++ b/src/mjswan/template/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite';
+import { defineConfig, type Plugin } from 'vite';
 import react from '@vitejs/plugin-react';
 import { vanillaExtractPlugin } from '@vanilla-extract/vite-plugin';
 import path from 'path';
@@ -19,6 +19,47 @@ function getVersionFromPython(): string {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const pkg = require('./package.json');
   return pkg.version || '0.0.0';
+}
+
+const isMt = process.env.MJSWAN_MT === '1';
+const coiSwPath = path.resolve(__dirname, '_mt/coi-serviceworker.js');
+
+function mtPlugin(enabled: boolean): Plugin | null {
+  if (!enabled) return null;
+  return {
+    name: 'mjswan-mt',
+    configureServer(server) {
+      // Serve the SW file during `vite dev` so the browser can register it.
+      server.middlewares.use('/coi-serviceworker.js', (_req, res) => {
+        res.setHeader('Content-Type', 'application/javascript');
+        res.end(fs.readFileSync(coiSwPath, 'utf-8'));
+      });
+    },
+    generateBundle() {
+      // Emit the SW file only when building the mt variant.
+      this.emitFile({
+        type: 'asset',
+        fileName: 'coi-serviceworker.js',
+        source: fs.readFileSync(coiSwPath, 'utf-8'),
+      });
+    },
+    transformIndexHtml(html: string) {
+      // Register the COOP/COEP service worker early in <head>.
+      // Required for GitHub Pages hosting (cannot set response headers).
+      // On Netlify / Cloudflare Pages / Vercel the _headers file is used instead.
+      const swScript =
+        `<script>\n` +
+        `    /* Register COOP/COEP service worker — required for GitHub Pages hosting */\n` +
+        `    if (!window.crossOriginIsolated && 'serviceWorker' in navigator) {\n` +
+        `      document.documentElement.style.display = 'none';\n` +
+        `      navigator.serviceWorker.register('coi-serviceworker.js').then(function() {\n` +
+        `        window.location.reload();\n` +
+        `      });\n` +
+        `    }\n` +
+        `  </script>`;
+      return html.replace('<meta charset="utf-8" />', `<meta charset="utf-8" />\n  ${swScript}`);
+    },
+  };
 }
 
 function gtmPlugin(gtmId: string | undefined) {
@@ -47,10 +88,11 @@ function gtmPlugin(gtmId: string | undefined) {
 }
 
 export default defineConfig({
-  plugins: [react(), vanillaExtractPlugin(), gtmPlugin(process.env.MJSWAN_GTM_ID)],
+  plugins: [react(), vanillaExtractPlugin(), mtPlugin(isMt), gtmPlugin(process.env.MJSWAN_GTM_ID)],
   base: process.env.MJSWAN_BASE_PATH || '/',
   define: {
     __APP_VERSION__: JSON.stringify(getVersionFromPython()),
+    __MUJOCO_MT__: JSON.stringify(isMt),
   },
   resolve: {
     alias: {
@@ -58,12 +100,16 @@ export default defineConfig({
     },
   },
   optimizeDeps: {
-    exclude: ['mujoco'],
+    exclude: ['mujoco', 'mujoco/mt'],
   },
   assetsInclude: ['**/*.wasm'],
   server: {
     port: 8000,
     host: true,
+    headers: isMt ? {
+      'Cross-Origin-Opener-Policy': 'same-origin',
+      'Cross-Origin-Embedder-Policy': 'require-corp',
+    } : {},
   },
   build: {
     outDir: 'dist',

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -681,6 +681,105 @@ class TestFullBuild:
         assert isinstance(app, mjswan.mjswanApp)
 
 
+# ===========================================================================
+# L1 — mt parameter: _save_mt_headers / no-headers when mt=False
+# ===========================================================================
+class TestMtHeaders:
+    def test_mt_defaults_to_false(self):
+        assert Builder()._mt is False
+
+    def test_mt_true_stored(self):
+        assert Builder(mt=True)._mt is True
+
+    def test_save_mt_headers_creates_headers_file(self, tmp_path):
+        Builder()._save_mt_headers(tmp_path)
+        assert (tmp_path / "_headers").exists()
+
+    def test_save_mt_headers_contains_coop(self, tmp_path):
+        Builder()._save_mt_headers(tmp_path)
+        content = (tmp_path / "_headers").read_text()
+        assert "Cross-Origin-Opener-Policy: same-origin" in content
+
+    def test_save_mt_headers_contains_coep(self, tmp_path):
+        Builder()._save_mt_headers(tmp_path)
+        content = (tmp_path / "_headers").read_text()
+        assert "Cross-Origin-Embedder-Policy: require-corp" in content
+
+    def test_save_mt_headers_applies_wildcard_route(self, tmp_path):
+        Builder()._save_mt_headers(tmp_path)
+        content = (tmp_path / "_headers").read_text()
+        assert content.startswith("/*")
+
+    def test_mt_false_does_not_write_headers(
+        self, tmp_path, minimal_model, monkeypatch
+    ):
+        """_save_web with mt=False must not create _headers."""
+        monkeypatch.setattr("mjswan.builder.ClientBuilder", MagicMock())
+        monkeypatch.setattr("mjswan.builder.shutil.copytree", MagicMock())
+        builder = Builder(mt=False)
+        builder.add_project(name="P").add_scene(name="S", model=minimal_model)
+        out = tmp_path / "out"
+        builder._save_web(out)
+        assert not (out / "_headers").exists()
+
+    def test_mt_true_writes_headers(self, tmp_path, minimal_model, monkeypatch):
+        """_save_web with mt=True must create _headers with COOP/COEP content."""
+        monkeypatch.setattr("mjswan.builder.ClientBuilder", MagicMock())
+        monkeypatch.setattr("mjswan.builder.shutil.copytree", MagicMock())
+        builder = Builder(mt=True)
+        builder.add_project(name="P").add_scene(name="S", model=minimal_model)
+        out = tmp_path / "out"
+        builder._save_web(out)
+        headers_file = out / "_headers"
+        assert headers_file.exists()
+        content = headers_file.read_text()
+        assert "Cross-Origin-Opener-Policy: same-origin" in content
+        assert "Cross-Origin-Embedder-Policy: require-corp" in content
+
+
+# ===========================================================================
+# L3 slow — full mt=True build (triggers frontend compilation)
+# Run with: pytest -m slow
+# ===========================================================================
+@pytest.mark.slow
+class TestFullBuildMt:
+    def test_mt_false_no_headers_file(self, tmp_path, minimal_model):
+        builder = Builder(mt=False)
+        builder.add_project(name="Test").add_scene(name="Scene", model=minimal_model)
+        builder.build(tmp_path / "out")
+        assert not (tmp_path / "out" / "_headers").exists()
+
+    def test_mt_false_no_coi_serviceworker(self, tmp_path, minimal_model):
+        builder = Builder(mt=False)
+        builder.add_project(name="Test").add_scene(name="Scene", model=minimal_model)
+        builder.build(tmp_path / "out")
+        assert not (tmp_path / "out" / "coi-serviceworker.js").exists()
+
+    def test_mt_true_writes_headers_file(self, tmp_path, minimal_model):
+        builder = Builder(mt=True)
+        builder.add_project(name="Test").add_scene(name="Scene", model=minimal_model)
+        builder.build(tmp_path / "out")
+        headers = tmp_path / "out" / "_headers"
+        assert headers.exists()
+        content = headers.read_text()
+        assert "Cross-Origin-Opener-Policy: same-origin" in content
+        assert "Cross-Origin-Embedder-Policy: require-corp" in content
+
+    def test_mt_true_emits_coi_serviceworker(self, tmp_path, minimal_model):
+        builder = Builder(mt=True)
+        builder.add_project(name="Test").add_scene(name="Scene", model=minimal_model)
+        builder.build(tmp_path / "out")
+        assert (tmp_path / "out" / "coi-serviceworker.js").exists()
+
+    def test_mt_true_injects_sw_script_into_html(self, tmp_path, minimal_model):
+        builder = Builder(mt=True)
+        builder.add_project(name="Test").add_scene(name="Scene", model=minimal_model)
+        builder.build(tmp_path / "out")
+        html = (tmp_path / "out" / "index.html").read_text()
+        assert "coi-serviceworker.js" in html
+        assert "crossOriginIsolated" in html
+
+
 @pytest.mark.slow
 class TestFullBuildGtmId:
     def test_gtm_snippet_injected_into_all_html_files(self, tmp_path, minimal_model):


### PR DESCRIPTION
## Summary

- Add `mt: bool` parameter to `Builder` (and `Builder.from_mjlab`) to opt in to the multi-threaded MuJoCo WASM build (`mujoco/mt`)
- Wire up cross-origin isolation (required for `SharedArrayBuffer`) via three mechanisms: `_headers` file (Netlify/Cloudflare Pages/Vercel), `coi-serviceworker.js` for GitHub Pages (which cannot set response headers), and Vite dev-server headers
- `MjswanViewer` conditionally imports `mujoco/mt` vs `mujoco` based on the `__MUJOCO_MT__` compile-time constant injected by `vite.config.ts`
- Update `setup-uv` GitHub Actions action v5 → v7
- Fix TypeScript imports from `@mujoco/mujoco` → `mujoco` across example files

## Test plan

- [ ] Build with `mt=False` (default) — verify standard single-threaded build works as before
- [ ] Build with `mt=True` — verify `coi-serviceworker.js` is emitted and `_headers` is written to output
- [ ] Open the `mt=True` build on GitHub Pages and confirm `crossOriginIsolated === true` in the browser console
- [ ] Open the `mt=True` build locally via `app.launch()` and confirm simulation loads with the MT WASM module
- [ ] Confirm CI passes (deploy workflow, lint, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)