### PR TITLE
Add app.launch(colab=True) for Google Colab support

### DIFF
--- a/examples/colab/demo.ipynb
+++ b/examples/colab/demo.ipynb
@@ -3,11 +3,11 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
-        "id": "view-in-github"
+        "id": "view-in-github",
+        "colab_type": "text"
       },
       "source": [
-        "<a href=\"https://colab.research.google.com/github/ttktjmt/mjswan/blob/main/examples/colab/demo.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+        "<a href=\"https://colab.research.google.com/github/ttktjmt/mjswan/blob/claude%2Fcolab-launch-support-PXAmX/examples/colab/demo.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
       ]
     },
     {
@@ -32,13 +32,27 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "xEUQ3T60-dBF"
+        "id": "xEUQ3T60-dBF",
+        "collapsed": true
       },
       "outputs": [],
       "source": [
-        "!if [ ! -d \"mjswan\" ]; then git clone -q --recursive https://github.com/ttktjmt/mjswan.git; fi\n",
-        "%cd /content/mjswan"
+        "!if [ ! -d \"mjswan\" ]; then git clone -q https://github.com/ttktjmt/mjswan.git; fi\n",
+        "%cd /content/mjswan\n",
+        "!uv pip install --system -e . --all-extras -r pyproject.toml -q"
       ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "import sys\n",
+        "sys.path.insert(0, \"/content/mjswan/src\")"
+      ],
+      "metadata": {
+        "id": "c3aSeZDjXsHX"
+      },
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -57,7 +71,7 @@
       },
       "outputs": [],
       "source": [
-        "!MJSWAN_NO_LAUNCH=\"1\" uv run --all-extras simple"
+        "!MJSWAN_NO_LAUNCH=\"1\" uv run simple"
       ]
     },
     {
@@ -80,15 +94,15 @@
         "from pathlib import Path\n",
         "import mjswan\n",
         "\n",
-        "app = mjswan.mjswanApp(Path(\"examples/demo/dist\"))\n",
-        "app.launch(colab=True)"
+        "app = mjswan.mjswanApp(Path(\"/content/mjswan/examples/demo/dist\"))\n",
+        "app.launch(colab=True, height=300)"
       ]
     }
   ],
   "metadata": {
     "colab": {
-      "include_colab_link": true,
-      "provenance": []
+      "provenance": [],
+      "include_colab_link": true
     },
     "kernelspec": {
       "display_name": "Python 3",

--- a/examples/colab/demo.ipynb
+++ b/examples/colab/demo.ipynb
@@ -7,7 +7,7 @@
         "id": "view-in-github"
       },
       "source": [
-        "<a href=\"https://colab.research.google.com/github/ttktjmt/muwanx/blob/main/examples/colab/demo.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+        "<a href=\"https://colab.research.google.com/github/ttktjmt/mjswan/blob/main/examples/colab/demo.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
       ]
     },
     {
@@ -66,53 +66,22 @@
         "id": "EU1mEWPeLP_B"
       },
       "source": [
-        "## **🌐 Serve Visualization**"
+        "## **🌐 Launch Viewer**"
       ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "collapsed": true,
         "id": "ibRFYEaK_yHy"
       },
       "outputs": [],
       "source": [
-        "import http.server\n",
-        "import socketserver\n",
-        "import threading\n",
+        "from pathlib import Path\n",
+        "import mjswan\n",
         "\n",
-        "PORT = 8000\n",
-        "DIRECTORY = \"examples/demo/dist\"\n",
-        "\n",
-        "\n",
-        "class Handler(http.server.SimpleHTTPRequestHandler):\n",
-        "    def __init__(self, *args, **kwargs):\n",
-        "        super().__init__(*args, directory=DIRECTORY, **kwargs)\n",
-        "\n",
-        "\n",
-        "def start_server():\n",
-        "    with socketserver.TCPServer((\"\", PORT), Handler) as httpd:\n",
-        "        print(f\"Serving at port {PORT}\")\n",
-        "        httpd.serve_forever()\n",
-        "\n",
-        "\n",
-        "thread = threading.Thread(target=start_server, daemon=True)\n",
-        "thread.start()"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "collapsed": true,
-        "id": "r4ryVPOD_0Cq"
-      },
-      "outputs": [],
-      "source": [
-        "from google.colab import output\n",
-        "\n",
-        "output.serve_kernel_port_as_iframe(PORT, height=\"600\")"
+        "app = mjswan.mjswanApp(Path(\"examples/demo/dist\"))\n",
+        "app.launch(colab=True)"
       ]
     }
   ],

--- a/examples/colab/demo.ipynb
+++ b/examples/colab/demo.ipynb
@@ -1,117 +1,119 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "view-in-github",
-        "colab_type": "text"
-      },
-      "source": [
-        "<a href=\"https://colab.research.google.com/github/ttktjmt/mjswan/blob/claude%2Fcolab-launch-support-PXAmX/examples/colab/demo.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "KJn2WCWEL6he"
-      },
-      "source": [
-        "# **🦢 mjswan Demo Tutorial**"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "bOs4_TTjK1Jq"
-      },
-      "source": [
-        "## **⚙️ Setup**"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "xEUQ3T60-dBF",
-        "collapsed": true
-      },
-      "outputs": [],
-      "source": [
-        "!if [ ! -d \"mjswan\" ]; then git clone -q https://github.com/ttktjmt/mjswan.git; fi\n",
-        "%cd /content/mjswan\n",
-        "!uv pip install --system -e . --all-extras -r pyproject.toml -q"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "import sys\n",
-        "sys.path.insert(0, \"/content/mjswan/src\")"
-      ],
-      "metadata": {
-        "id": "c3aSeZDjXsHX"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "Ryhvdy6yK_Rr"
-      },
-      "source": [
-        "## **🚀 Generate the Demo App**"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "V6R6AN0Q_thl"
-      },
-      "outputs": [],
-      "source": [
-        "!MJSWAN_NO_LAUNCH=\"1\" uv run simple"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "EU1mEWPeLP_B"
-      },
-      "source": [
-        "## **🌐 Launch Viewer**"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "ibRFYEaK_yHy"
-      },
-      "outputs": [],
-      "source": [
-        "from pathlib import Path\n",
-        "import mjswan\n",
-        "\n",
-        "app = mjswan.mjswanApp(Path(\"/content/mjswan/examples/demo/dist\"))\n",
-        "app.launch(colab=True, height=300)"
-      ]
-    }
-  ],
-  "metadata": {
-    "colab": {
-      "provenance": [],
-      "include_colab_link": true
-    },
-    "kernelspec": {
-      "display_name": "Python 3",
-      "name": "python3"
-    },
-    "language_info": {
-      "name": "python"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "view-in-github"
+   },
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/ttktjmt/mjswan/blob/claude%2Fcolab-launch-support-PXAmX/examples/colab/demo.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 0
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "KJn2WCWEL6he"
+   },
+   "source": [
+    "# **🦢 mjswan Demo Tutorial**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "bOs4_TTjK1Jq"
+   },
+   "source": [
+    "## **⚙️ Setup**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true,
+    "id": "xEUQ3T60-dBF"
+   },
+   "outputs": [],
+   "source": [
+    "!if [ ! -d \"mjswan\" ]; then git clone -q https://github.com/ttktjmt/mjswan.git; fi\n",
+    "%cd /content/mjswan\n",
+    "!uv pip install --system -e . --all-extras -r pyproject.toml -q"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "c3aSeZDjXsHX"
+   },
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "\n",
+    "sys.path.insert(0, \"/content/mjswan/src\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Ryhvdy6yK_Rr"
+   },
+   "source": [
+    "## **🚀 Generate the Demo App**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "V6R6AN0Q_thl"
+   },
+   "outputs": [],
+   "source": [
+    "!MJSWAN_NO_LAUNCH=\"1\" uv run simple"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "EU1mEWPeLP_B"
+   },
+   "source": [
+    "## **🌐 Launch Viewer**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "ibRFYEaK_yHy"
+   },
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "\n",
+    "import mjswan\n",
+    "\n",
+    "app = mjswan.mjswanApp(Path(\"/content/mjswan/examples/demo/dist\"))\n",
+    "app.launch(colab=True, height=300)"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "include_colab_link": true,
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,9 +132,6 @@ override-dependencies = [
     "h5py>=3.8.0",
 ]
 
-[tool.uv.sources]
-warp-lang = { index = "nvidia", marker = "sys_platform != 'darwin'" }
-
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 markers = [

--- a/src/mjswan/app.py
+++ b/src/mjswan/app.py
@@ -34,11 +34,8 @@ class mjswanApp:
             host: Host to bind the server to.
             port: Port to run the server on.
             open_browser: Whether to automatically open a browser.
-            colab: Run in Google Colab mode — starts a background thread server
-                and displays the viewer as an inline iframe via
-                ``google.colab.output.serve_kernel_port_as_iframe``.
-            height: Height of the Colab iframe in pixels (only used when
-                ``colab=True``).
+            colab: Run in Google Colab mode.
+            height: Height of the Colab iframe in pixels (only used when ``colab=True``).
         """
         if not self._app_dir.exists():
             raise RuntimeError(f"Application directory {self._app_dir} does not exist.")
@@ -60,9 +57,6 @@ class mjswanApp:
                 self.send_header("Cross-Origin-Opener-Policy", "same-origin")
                 self.send_header("Cross-Origin-Embedder-Policy", "require-corp")
                 super().end_headers()
-
-            def log_message(self, format, *args):  # noqa: A002
-                pass  # suppress per-request access logs
 
         handler = CrossOriginIsolatedHandler
 

--- a/src/mjswan/app.py
+++ b/src/mjswan/app.py
@@ -25,6 +25,8 @@ class mjswanApp:
         host: str = "localhost",
         port: int = 8080,
         open_browser: bool = True,
+        colab: bool = False,
+        height: int = 600,
     ) -> None:
         """Launch the application in a local web server.
 
@@ -32,6 +34,11 @@ class mjswanApp:
             host: Host to bind the server to.
             port: Port to run the server on.
             open_browser: Whether to automatically open a browser.
+            colab: Run in Google Colab mode — starts a background thread server
+                and displays the viewer as an inline iframe via
+                ``google.colab.output.serve_kernel_port_as_iframe``.
+            height: Height of the Colab iframe in pixels (only used when
+                ``colab=True``).
         """
         if not self._app_dir.exists():
             raise RuntimeError(f"Application directory {self._app_dir} does not exist.")
@@ -39,7 +46,6 @@ class mjswanApp:
         import http.server
         import socket
         import socketserver
-        import webbrowser
 
         directory = str(self._app_dir)
 
@@ -54,6 +60,9 @@ class mjswanApp:
                 self.send_header("Cross-Origin-Opener-Policy", "same-origin")
                 self.send_header("Cross-Origin-Embedder-Policy", "require-corp")
                 super().end_headers()
+
+            def log_message(self, format, *args):  # noqa: A002
+                pass  # suppress per-request access logs
 
         handler = CrossOriginIsolatedHandler
 
@@ -73,6 +82,33 @@ class mjswanApp:
                         tries += 1
             raise RuntimeError(f"No available port found starting at {start_port}")
 
+        class _ReusableTCPServer(socketserver.TCPServer):
+            allow_reuse_address = True
+
+        if colab:
+            bind_host = ""
+            chosen_port = _find_available_port(bind_host, port)
+            if chosen_port != port:
+                print(f"Port {port} unavailable — using port {chosen_port} instead.")
+            port = chosen_port
+
+            import threading
+
+            def _serve():
+                with _ReusableTCPServer((bind_host, port), handler) as httpd:
+                    httpd.serve_forever()
+
+            thread = threading.Thread(target=_serve, daemon=True)
+            thread.start()
+            print(f"Server running on port {port}")
+
+            from google.colab import output  # type: ignore[import]
+
+            output.serve_kernel_port_as_iframe(port, height=str(height))
+            return
+
+        import webbrowser
+
         chosen_port = _find_available_port(host, port)
         if chosen_port != port:
             print(f"Port {port} unavailable — using port {chosen_port} instead.")
@@ -81,9 +117,6 @@ class mjswanApp:
         print(f"Starting server at http://{host}:{port}")
         if open_browser:
             webbrowser.open(f"http://{host}:{port}")
-
-        class _ReusableTCPServer(socketserver.TCPServer):
-            allow_reuse_address = True
 
         try:
             with _ReusableTCPServer((host, port), handler) as httpd:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,4 +1,4 @@
-"""Tests for mjswanApp.launch().
+"""Tests for mjswanApp.
 
 L1 — pure Python, no MuJoCo/ONNX required (safe for pre-commit).
 """

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,132 @@
+"""Tests for mjswanApp.launch().
+
+L1 — pure Python, no MuJoCo/ONNX required (safe for pre-commit).
+"""
+
+import sys
+import threading as _threading_module
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+import socket as _socket_module
+import socketserver as _socketserver_module
+import webbrowser as _webbrowser_module
+
+from mjswan.app import mjswanApp
+
+
+class _MockTCPServer:
+    """No-op stand-in for socketserver.TCPServer."""
+
+    allow_reuse_address = True
+
+    def __init__(self, address, handler):
+        self.address = address
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        pass
+
+    def serve_forever(self):
+        pass
+
+
+@pytest.fixture(autouse=True)
+def _patch_tcp_server(monkeypatch):
+    monkeypatch.setattr(_socketserver_module, "TCPServer", _MockTCPServer)
+
+
+@pytest.fixture(autouse=True)
+def _patch_socket(monkeypatch):
+    # Makes _find_available_port always succeed without touching real ports.
+    monkeypatch.setattr(_socket_module, "socket", MagicMock())
+
+
+@pytest.fixture
+def app_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "dist"
+    d.mkdir()
+    return d
+
+
+class TestMjswanAppValidation:
+    def test_raises_if_app_dir_missing(self, tmp_path):
+        with pytest.raises(RuntimeError, match="does not exist"):
+            mjswanApp(tmp_path / "nonexistent").launch()
+
+
+class TestMjswanAppNormalMode:
+    def test_opens_browser_by_default(self, app_dir, monkeypatch):
+        mock_open = MagicMock()
+        monkeypatch.setattr(_webbrowser_module, "open", mock_open)
+        mjswanApp(app_dir).launch()
+        mock_open.assert_called_once()
+
+    def test_skips_browser_when_open_browser_false(self, app_dir, monkeypatch):
+        mock_open = MagicMock()
+        monkeypatch.setattr(_webbrowser_module, "open", mock_open)
+        mjswanApp(app_dir).launch(open_browser=False)
+        mock_open.assert_not_called()
+
+    def test_browser_url_uses_host_and_port(self, app_dir, monkeypatch):
+        mock_open = MagicMock()
+        monkeypatch.setattr(_webbrowser_module, "open", mock_open)
+        mjswanApp(app_dir).launch(host="127.0.0.1", port=9000)
+        mock_open.assert_called_once_with("http://127.0.0.1:9000")
+
+
+class TestMjswanAppColabMode:
+    @pytest.fixture
+    def mock_colab_output(self, monkeypatch):
+        mock_output = MagicMock()
+        mock_google_colab = MagicMock()
+        mock_google_colab.output = mock_output
+        mock_google = MagicMock()
+        mock_google.colab = mock_google_colab
+        monkeypatch.setitem(sys.modules, "google", mock_google)
+        monkeypatch.setitem(sys.modules, "google.colab", mock_google_colab)
+        return mock_output
+
+    @pytest.fixture
+    def mock_thread(self, monkeypatch):
+        thread_instance = MagicMock()
+        thread_cls = MagicMock(return_value=thread_instance)
+        monkeypatch.setattr(_threading_module, "Thread", thread_cls)
+        return thread_cls, thread_instance
+
+    def test_does_not_open_browser(
+        self, app_dir, monkeypatch, mock_colab_output, mock_thread
+    ):
+        mock_open = MagicMock()
+        monkeypatch.setattr(_webbrowser_module, "open", mock_open)
+        mjswanApp(app_dir).launch(colab=True)
+        mock_open.assert_not_called()
+
+    def test_starts_daemon_thread(self, app_dir, mock_colab_output, mock_thread):
+        thread_cls, thread_instance = mock_thread
+        mjswanApp(app_dir).launch(colab=True)
+        thread_cls.assert_called_once()
+        _, kwargs = thread_cls.call_args
+        assert kwargs.get("daemon") is True
+        thread_instance.start.assert_called_once()
+
+    def test_calls_serve_kernel_port_as_iframe(
+        self, app_dir, mock_colab_output, mock_thread
+    ):
+        mjswanApp(app_dir).launch(colab=True, port=8080)
+        mock_colab_output.serve_kernel_port_as_iframe.assert_called_once_with(
+            8080, height="600"
+        )
+
+    def test_respects_height_parameter(self, app_dir, mock_colab_output, mock_thread):
+        mjswanApp(app_dir).launch(colab=True, port=8080, height=800)
+        mock_colab_output.serve_kernel_port_as_iframe.assert_called_once_with(
+            8080, height="800"
+        )
+
+    def test_returns_immediately(self, app_dir, mock_colab_output, mock_thread):
+        result = mjswanApp(app_dir).launch(colab=True)
+        assert result is None

--- a/uv.lock
+++ b/uv.lock
@@ -1877,8 +1877,8 @@ wheels = [
 
 [[package]]
 name = "mjlab"
-version = "1.3.0"
-source = { registry = "https://pypi.org/simple" }
+version = "1.2.0"
+source = { git = "https://github.com/mujocolab/mjlab.git#e2a405a8ddf8176a2873834b63fcf3e5c388aa80" }
 dependencies = [
     { name = "imageio-ffmpeg" },
     { name = "mediapy" },
@@ -1898,10 +1898,6 @@ dependencies = [
     { name = "viser" },
     { name = "wandb" },
     { name = "warp-lang" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b4/b4/8dc349ffdc26a5497ceb9a95b978abf77e54aaa8ea4e26fe18c3b4715c68/mjlab-1.3.0.tar.gz", hash = "sha256:7514f6703a801978f4b04ddee6e915531e020b4993b26939be91c2cc37ceed99", size = 14066827, upload-time = "2026-04-14T20:16:44.222Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c4/de/8b796d06d6e1543782179d608077b32c4e258fb0dfbc62fed516197fe179/mjlab-1.3.0-py3-none-any.whl", hash = "sha256:e3b544bf3e7b69d6de0641c0f98fa3c9bb9d8ff662951ad83dcaba4db4fe47cf", size = 14158107, upload-time = "2026-04-14T20:16:47.197Z" },
 ]
 
 [[package]]
@@ -1934,7 +1930,7 @@ examples = [
 [package.metadata]
 requires-dist = [
     { name = "gymnasium", marker = "extra == 'examples'" },
-    { name = "mjlab", marker = "extra == 'examples'", specifier = ">=1.3.0" },
+    { name = "mjlab", marker = "extra == 'examples'", git = "https://github.com/mujocolab/mjlab.git" },
     { name = "mujoco", specifier = "==3.7.0" },
     { name = "myosuite", marker = "extra == 'examples'" },
     { name = "nodeenv", specifier = ">=1.9.1" },
@@ -2138,8 +2134,8 @@ wheels = [
 
 [[package]]
 name = "mujoco-warp"
-version = "3.7.0.1"
-source = { registry = "https://pypi.org/simple" }
+version = "3.6.0"
+source = { git = "https://github.com/google-deepmind/mujoco_warp?rev=875c4caf06d71b12b2036c327e7a07ce08a78b9a#875c4caf06d71b12b2036c327e7a07ce08a78b9a" }
 dependencies = [
     { name = "absl-py" },
     { name = "etils", version = "1.13.0", source = { registry = "https://pypi.org/simple" }, extra = ["epath"], marker = "python_full_version < '3.11'" },
@@ -2148,10 +2144,6 @@ dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "warp-lang" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/33/e8/c4838f00004197bb8c1810f0a541f760930f11a792e437023c6d85459f34/mujoco_warp-3.7.0.1.tar.gz", hash = "sha256:7c664139ef038212c2c4f4d355a154f70fcaffe9a308f95bfe7b50ab5df8802f", size = 1912756, upload-time = "2026-04-14T17:23:40.634Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/90/a6/23d2c61ebfd34c8279bce9222b09a4d1bf7a872b9d673fc81713c3583d57/mujoco_warp-3.7.0.1-py3-none-any.whl", hash = "sha256:93361c15b9540bcb8e752ffe9c8dd424b30ee6a604864a7cbe92019f1a4a8918", size = 1994142, upload-time = "2026-04-14T17:23:39.006Z" },
 ]
 
 [[package]]
@@ -4142,16 +4134,16 @@ wheels = [
 [[package]]
 name = "warp-lang"
 version = "1.12.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi.nvidia.com/" }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7d/15/fadf3e3ba5c1c907530c20c98402aaef792da74bbbe382c848cef6e5affe/warp_lang-1.12.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c78c3701d5cad86c30ef5017410d294ec46a396bb0d502ee1c98743494f3a62f", size = 24168341, upload-time = "2026-03-06T19:42:16.333Z" },
-    { url = "https://files.pythonhosted.org/packages/98/13/deab9dbae5c6aa753ac8ea1d3b1f85d20c5bab7bdebd8916ce242fbe1f0b/warp_lang-1.12.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:a1436f60a1881cd94f787e751a83fc0987626be2d3e2b4e74c64a6947c6d1266", size = 136485344, upload-time = "2026-03-06T19:43:02.427Z" },
-    { url = "https://files.pythonhosted.org/packages/45/ce/9f5c57cac849edaba2f3335cb649b7019b09195b3af02221258482254559/warp_lang-1.12.0-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:a2d6decba693aba5b828573c4414fd6a3f4c4a934db9c322736ef2b3fa99fe76", size = 137735580, upload-time = "2026-03-06T19:44:22.279Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/3f/1ddc888fe769447ae33915a9567a9dd7467e1fc7fc8010d39e01b339667f/warp_lang-1.12.0-py3-none-win_amd64.whl", hash = "sha256:697248edd2f1e2952f50e3db33b214af76173641a8894aacc467bed6dc247f8a", size = 119793582, upload-time = "2026-03-06T19:45:37.288Z" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.12.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c78c3701d5cad86c30ef5017410d294ec46a396bb0d502ee1c98743494f3a62f" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.12.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:a1436f60a1881cd94f787e751a83fc0987626be2d3e2b4e74c64a6947c6d1266" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.12.0-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:a2d6decba693aba5b828573c4414fd6a3f4c4a934db9c322736ef2b3fa99fe76" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.12.0-py3-none-win_amd64.whl", hash = "sha256:697248edd2f1e2952f50e3db33b214af76173641a8894aacc467bed6dc247f8a" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1877,8 +1877,8 @@ wheels = [
 
 [[package]]
 name = "mjlab"
-version = "1.2.0"
-source = { git = "https://github.com/mujocolab/mjlab.git#e2a405a8ddf8176a2873834b63fcf3e5c388aa80" }
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "imageio-ffmpeg" },
     { name = "mediapy" },
@@ -1898,6 +1898,10 @@ dependencies = [
     { name = "viser" },
     { name = "wandb" },
     { name = "warp-lang" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b4/b4/8dc349ffdc26a5497ceb9a95b978abf77e54aaa8ea4e26fe18c3b4715c68/mjlab-1.3.0.tar.gz", hash = "sha256:7514f6703a801978f4b04ddee6e915531e020b4993b26939be91c2cc37ceed99", size = 14066827, upload-time = "2026-04-14T20:16:44.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/de/8b796d06d6e1543782179d608077b32c4e258fb0dfbc62fed516197fe179/mjlab-1.3.0-py3-none-any.whl", hash = "sha256:e3b544bf3e7b69d6de0641c0f98fa3c9bb9d8ff662951ad83dcaba4db4fe47cf", size = 14158107, upload-time = "2026-04-14T20:16:47.197Z" },
 ]
 
 [[package]]
@@ -1930,7 +1934,7 @@ examples = [
 [package.metadata]
 requires-dist = [
     { name = "gymnasium", marker = "extra == 'examples'" },
-    { name = "mjlab", marker = "extra == 'examples'", git = "https://github.com/mujocolab/mjlab.git" },
+    { name = "mjlab", marker = "extra == 'examples'", specifier = ">=1.3.0" },
     { name = "mujoco", specifier = "==3.7.0" },
     { name = "myosuite", marker = "extra == 'examples'" },
     { name = "nodeenv", specifier = ">=1.9.1" },
@@ -2134,8 +2138,8 @@ wheels = [
 
 [[package]]
 name = "mujoco-warp"
-version = "3.6.0"
-source = { git = "https://github.com/google-deepmind/mujoco_warp?rev=875c4caf06d71b12b2036c327e7a07ce08a78b9a#875c4caf06d71b12b2036c327e7a07ce08a78b9a" }
+version = "3.7.0.1"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "absl-py" },
     { name = "etils", version = "1.13.0", source = { registry = "https://pypi.org/simple" }, extra = ["epath"], marker = "python_full_version < '3.11'" },
@@ -2144,6 +2148,10 @@ dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "warp-lang" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/33/e8/c4838f00004197bb8c1810f0a541f760930f11a792e437023c6d85459f34/mujoco_warp-3.7.0.1.tar.gz", hash = "sha256:7c664139ef038212c2c4f4d355a154f70fcaffe9a308f95bfe7b50ab5df8802f", size = 1912756, upload-time = "2026-04-14T17:23:40.634Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/a6/23d2c61ebfd34c8279bce9222b09a4d1bf7a872b9d673fc81713c3583d57/mujoco_warp-3.7.0.1-py3-none-any.whl", hash = "sha256:93361c15b9540bcb8e752ffe9c8dd424b30ee6a604864a7cbe92019f1a4a8918", size = 1994142, upload-time = "2026-04-14T17:23:39.006Z" },
 ]
 
 [[package]]
@@ -4134,16 +4142,16 @@ wheels = [
 [[package]]
 name = "warp-lang"
 version = "1.12.0"
-source = { registry = "https://pypi.nvidia.com/" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 wheels = [
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.12.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c78c3701d5cad86c30ef5017410d294ec46a396bb0d502ee1c98743494f3a62f" },
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.12.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:a1436f60a1881cd94f787e751a83fc0987626be2d3e2b4e74c64a6947c6d1266" },
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.12.0-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:a2d6decba693aba5b828573c4414fd6a3f4c4a934db9c322736ef2b3fa99fe76" },
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.12.0-py3-none-win_amd64.whl", hash = "sha256:697248edd2f1e2952f50e3db33b214af76173641a8894aacc467bed6dc247f8a" },
+    { url = "https://files.pythonhosted.org/packages/7d/15/fadf3e3ba5c1c907530c20c98402aaef792da74bbbe382c848cef6e5affe/warp_lang-1.12.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c78c3701d5cad86c30ef5017410d294ec46a396bb0d502ee1c98743494f3a62f", size = 24168341, upload-time = "2026-03-06T19:42:16.333Z" },
+    { url = "https://files.pythonhosted.org/packages/98/13/deab9dbae5c6aa753ac8ea1d3b1f85d20c5bab7bdebd8916ce242fbe1f0b/warp_lang-1.12.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:a1436f60a1881cd94f787e751a83fc0987626be2d3e2b4e74c64a6947c6d1266", size = 136485344, upload-time = "2026-03-06T19:43:02.427Z" },
+    { url = "https://files.pythonhosted.org/packages/45/ce/9f5c57cac849edaba2f3335cb649b7019b09195b3af02221258482254559/warp_lang-1.12.0-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:a2d6decba693aba5b828573c4414fd6a3f4c4a934db9c322736ef2b3fa99fe76", size = 137735580, upload-time = "2026-03-06T19:44:22.279Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/3f/1ddc888fe769447ae33915a9567a9dd7467e1fc7fc8010d39e01b339667f/warp_lang-1.12.0-py3-none-win_amd64.whl", hash = "sha256:697248edd2f1e2952f50e3db33b214af76173641a8894aacc467bed6dc247f8a", size = 119793582, upload-time = "2026-03-06T19:45:37.288Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Starts the HTTP server in a daemon thread (non-blocking) and calls
google.colab.output.serve_kernel_port_as_iframe to display the viewer
inline. Also simplifies the Colab demo notebook from ~20 lines of manual
boilerplate across two cells to a single app.launch(colab=True) call.

Includes a height parameter (default 600px) for the iframe, COOP/COEP
headers are preserved for MuJoCo WASM threading, and per-request access
logs are suppressed.

https://claude.ai/code/session_016VnaVA8E7ebgqJkBEj1cHS