### PR TITLE
Auto-detect Colab environment instead of requiring colab=True

### DIFF
--- a/examples/colab/demo.ipynb
+++ b/examples/colab/demo.ipynb
@@ -97,7 +97,7 @@
     "import mjswan\n",
     "\n",
     "app = mjswan.mjswanApp(Path(\"/content/mjswan/examples/demo/dist\"))\n",
-    "app.launch(colab=True, height=300)"
+    "app.launch(height=300)"
    ]
   }
  ],

--- a/src/mjswan/app.py
+++ b/src/mjswan/app.py
@@ -9,6 +9,15 @@ from __future__ import annotations
 from pathlib import Path
 
 
+def _detect_colab() -> bool:
+    try:
+        import google.colab  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
 class mjswanApp:
     """A built mjswan application ready to be launched.
 
@@ -25,17 +34,19 @@ class mjswanApp:
         host: str = "localhost",
         port: int = 8080,
         open_browser: bool = True,
-        colab: bool = False,
         height: int = 600,
     ) -> None:
         """Launch the application in a local web server.
 
+        Automatically detects Google Colab and displays the viewer as an
+        inline iframe. Outside Colab, starts a blocking server and optionally
+        opens a browser tab.
+
         Args:
-            host: Host to bind the server to.
+            host: Host to bind the server to (ignored in Colab).
             port: Port to run the server on.
-            open_browser: Whether to automatically open a browser.
-            colab: Run in Google Colab mode.
-            height: Height of the Colab iframe in pixels (only used when ``colab=True``).
+            open_browser: Whether to automatically open a browser (ignored in Colab).
+            height: Height of the Colab iframe in pixels (ignored outside Colab).
         """
         if not self._app_dir.exists():
             raise RuntimeError(f"Application directory {self._app_dir} does not exist.")
@@ -79,7 +90,7 @@ class mjswanApp:
         class _ReusableTCPServer(socketserver.TCPServer):
             allow_reuse_address = True
 
-        if colab:
+        if _detect_colab():
             bind_host = ""
             chosen_port = _find_available_port(bind_host, port)
             if chosen_port != port:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -13,7 +13,7 @@ import socket as _socket_module
 import socketserver as _socketserver_module
 import webbrowser as _webbrowser_module
 
-from mjswan.app import mjswanApp
+from mjswan.app import _detect_colab, mjswanApp
 
 
 class _MockTCPServer:
@@ -50,6 +50,23 @@ def app_dir(tmp_path: Path) -> Path:
     d = tmp_path / "dist"
     d.mkdir()
     return d
+
+
+class TestDetectColab:
+    def test_returns_false_outside_colab(self):
+        assert _detect_colab() is False
+
+    def test_returns_true_when_google_colab_importable(self, monkeypatch):
+        mock_google_colab = MagicMock()
+        monkeypatch.setitem(sys.modules, "google.colab", mock_google_colab)
+        assert _detect_colab() is True
+
+    def test_returns_false_after_colab_removed(self, monkeypatch):
+        mock_google_colab = MagicMock()
+        monkeypatch.setitem(sys.modules, "google.colab", mock_google_colab)
+        assert _detect_colab() is True
+        monkeypatch.delitem(sys.modules, "google.colab")
+        assert _detect_colab() is False
 
 
 class TestMjswanAppValidation:
@@ -102,12 +119,12 @@ class TestMjswanAppColabMode:
     ):
         mock_open = MagicMock()
         monkeypatch.setattr(_webbrowser_module, "open", mock_open)
-        mjswanApp(app_dir).launch(colab=True)
+        mjswanApp(app_dir).launch()
         mock_open.assert_not_called()
 
     def test_starts_daemon_thread(self, app_dir, mock_colab_output, mock_thread):
         thread_cls, thread_instance = mock_thread
-        mjswanApp(app_dir).launch(colab=True)
+        mjswanApp(app_dir).launch()
         thread_cls.assert_called_once()
         _, kwargs = thread_cls.call_args
         assert kwargs.get("daemon") is True
@@ -116,17 +133,17 @@ class TestMjswanAppColabMode:
     def test_calls_serve_kernel_port_as_iframe(
         self, app_dir, mock_colab_output, mock_thread
     ):
-        mjswanApp(app_dir).launch(colab=True, port=8080)
+        mjswanApp(app_dir).launch(port=8080)
         mock_colab_output.serve_kernel_port_as_iframe.assert_called_once_with(
             8080, height="600"
         )
 
     def test_respects_height_parameter(self, app_dir, mock_colab_output, mock_thread):
-        mjswanApp(app_dir).launch(colab=True, port=8080, height=800)
+        mjswanApp(app_dir).launch(port=8080, height=800)
         mock_colab_output.serve_kernel_port_as_iframe.assert_called_once_with(
             8080, height="800"
         )
 
     def test_returns_immediately(self, app_dir, mock_colab_output, mock_thread):
-        result = mjswanApp(app_dir).launch(colab=True)
+        result = mjswanApp(app_dir).launch()
         assert result is None


### PR DESCRIPTION
Replace the explicit colab parameter with _detect_colab(), which tries to import google.colab and returns True only in a Colab runtime. Users can now call app.launch() without any arguments in both local and Colab environments.

Also adds TestDetectColab with 3 tests covering the detection logic.

https://claude.ai/code/session_016VnaVA8E7ebgqJkBEj1cHS